### PR TITLE
Don't call nonexistant --version on dscanner

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,10 +19,6 @@ class Dscanner(Linter):
 
     syntax = 'd'
     cmd = 'dscanner -S'
-    executable = None
-    version_args = '--version'
-    version_re = r'^.*(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 0.1.0'
     regex = r'^.+?\((?P<line>\d+):(?P<col>\d+)\)\[((?P<warning>warn)|(?P<error>error))\]: (?P<message>.+)$'
     multiline = False
     line_col_base = (1, 1)


### PR DESCRIPTION
This fixes the linter on my system. ST3 latest version, SL3 3.4.15 (latest version). 

The linter disables the dscanner linter when it notices it can't call dscanner with --version.
